### PR TITLE
Issue #15: Option to display in flat navigation

### DIFF
--- a/index.php
+++ b/index.php
@@ -61,7 +61,7 @@ foreach ($userlist as $user) {
 }
 
 // Finish setting up page.
-$PAGE->set_title($course->shortname .': '. get_string('roster' , 'report_roster'));
+$PAGE->set_title($course->shortname .': '. get_config('report_roster' , 'displayname'));
 $PAGE->set_heading($course->fullname);
 $PAGE->requires->js_call_amd('report_roster/roster', 'init');
 

--- a/lang/en/report_roster.php
+++ b/lang/en/report_roster.php
@@ -31,6 +31,23 @@ $string['learningmodeon'] = 'Learning mode on';
 $string['pluginname'] = 'Roster';
 $string['printmode'] = 'Printable';
 $string['privacy:metadata'] = 'The roster report only shows data stored in other locations.';
-$string['roster'] = 'Roster';
 $string['roster:view'] = 'View roster course report';
+$string['settings:displayname'] = 'Display name';
+$string['settings:displayname:description'] = 'This will display on the report page and in the navigation link.';
+$string['settings:displayname:default'] = 'Roster';
+$string['settings:flatnav'] = 'Display in flat navigation?';
+$string['settings:flatnav:description'] = 'If checked, a link to the Roster report will be added to the Boost flat navigation.
+(Under older themes like More, it will appear in the Navigation block under Current course > {coursename})';
+$string['settings:flatnav_position'] = 'Position in Flat Navigation';
+$string['settings:flatnav_position:description'] = 'A link to the report will be added *above* the link at the top of this list.
+If not found, it will try the next in the list, and so on. The first word on each line is the link identifier; everything afterward
+is ignored (so that the identifiers can be labelled). The main course navigation nodes are included by default; the identifiers for
+additional nodes can be obtained by looking at the `data-key` property of the relevant `<a>`.';
+$string['settings:flatnav_position:default'] = "
+badgesview (Badges)
+competencies (Competencies)
+grades (Grades)
+participants (Participants)
+";
 $string['webmode'] = 'Web report';
+

--- a/lib.php
+++ b/lib.php
@@ -35,7 +35,7 @@ function report_roster_extend_navigation_course($navigation, $course, $context) 
     if (has_capability('report/roster:view', $context)) {
         // If the setting is enabled, put a link to the report in the flat navigation.
         if (get_config('report_roster', 'flatnav')) {
-            add_to_flatnav();
+            report_roster_add_to_flatnav();
         }
 
         $url = new moodle_url('/report/roster/index.php', array('id' => $course->id));

--- a/lib.php
+++ b/lib.php
@@ -49,7 +49,7 @@ function report_roster_extend_navigation_course($navigation, $course, $context) 
  *
  * @return void
  */
-function add_to_flatnav() {
+function report_roster_add_to_flatnav() {
     global $PAGE, $COURSE;
 
     // Create the link.

--- a/lib.php
+++ b/lib.php
@@ -33,8 +33,67 @@ defined('MOODLE_INTERNAL') || die;
  */
 function report_roster_extend_navigation_course($navigation, $course, $context) {
     if (has_capability('report/roster:view', $context)) {
+        // If the setting is enabled, put a link to the report in the flat navigation.
+        if (get_config('report_roster', 'flatnav')) {
+            add_to_flatnav();
+        }
+
         $url = new moodle_url('/report/roster/index.php', array('id' => $course->id));
         $navigation->add(get_string('pluginname', 'report_roster'), $url,
                 navigation_node::TYPE_SETTING, null, null, new pix_icon('i/report', ''));
     }
+}
+
+/**
+ * Adds the Roster link to the flat course navigation.
+ *
+ * @return void
+ */
+function add_to_flatnav() {
+    global $PAGE, $COURSE;
+
+    // Create the link.
+    $node = $PAGE->navigation->create(
+        get_config('report_roster', 'displayname'),   // Link text.
+        '/report/roster/index.php?id=' . $COURSE->id, // URL.
+        navigation_node::TYPE_SETTING,                // Node type.
+        null,                                         // "Shorttext".
+        'report_roster',                              // Key.
+        new pix_icon('t/roster', '', 'report_roster') // Icon.
+    );
+
+    // Get course navigation node.
+    $coursenode = $PAGE->navigation->find($COURSE->id, navigation_node::TYPE_COURSE);
+    $children   = $coursenode->children;
+
+    // Figure out where to put the link, based on config.
+    // Note that the addkey is the node which our new link will be added *above*.
+    $addkey    = '';
+    $keyconfig = get_config('report_roster', 'flatnav_position');
+    $keys      = explode("\n", $keyconfig);
+    $keys      = array_map(function($k) {
+        return explode(' ', $k)[0];
+    }, $keys);
+
+    foreach ($keys as $key) {
+        if ($children->find($key)) {
+            $addkey = $key;
+            break;
+        }
+    }
+
+    // Add our link to the navigation.
+    $coursenode->add_node($node, $addkey);
+}
+
+/**
+ * Creates a mapping between the Moodle icon system and Font Awesome icons.
+ * See https://docs.moodle.org/dev/Moodle_icons#Font_awesome_icons.
+ *
+ * @return array
+ */
+function report_roster_get_fontawesome_icon_map() {
+    return [
+        'report_roster:t/roster' => 'fa-clipboard',
+    ];
 }

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,51 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Library functions for the roster report.
+ *
+ * @package   report_roster
+ * @copyright 2019 Lafayette College ITS
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+if ($ADMIN->fulltree) {
+    $settings->add(
+        new admin_setting_configcheckbox('report_roster/flatnav',
+            get_string('settings:flatnav', 'report_roster'),
+            get_string('settings:flatnav:description', 'report_roster'),
+            0
+        )
+    );
+
+    $settings->add(
+        new admin_setting_configtext('report_roster/displayname',
+            get_string('settings:displayname', 'report_roster'),
+            get_string('settings:displayname:description', 'report_roster'),
+            get_string('settings:displayname:default', 'report_roster')
+        )
+    );
+
+    $settings->add(
+        new admin_setting_configtextarea('report_roster/flatnav_position',
+            get_string('settings:flatnav_position', 'report_roster'),
+            get_string('settings:flatnav_position:description', 'report_roster'),
+            get_string('settings:flatnav_position:default', 'report_roster')
+        )
+    );
+}

--- a/tests/behat/behat_report_roster.php
+++ b/tests/behat/behat_report_roster.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * This file creates a behat step definition
+ *
+ * @package    report_roster
+ * @copyright  2018 CLAMP
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../../../lib/behat/behat_base.php');
+
+use Behat\Behat\Context\Step\Given as Given;
+use Behat\Gherkin\Node\PyStringNode as PyStringNode;
+
+/**
+ * Custom step definitions
+ *
+ * @package    report_roster
+ * @copyright  2019 CLAMP
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class behat_report_roster extends behat_base {
+    /**
+     * Sets a multiline config value as admin
+     *
+     * @Given /^I set the multiline "(?P<plugin_string>(?:[^"]|\\")*)" "(?P<name_string>(?:[^"]|\\")*)" setting as admin to:$/
+     * @param string $plugin The plugins Frankenstyle name
+     * @param string $name The name of the setting to be set_config
+     * @param PyStringNode $value A triple-quote delimited text block to be set as the value of the setting
+     */
+    public function i_set_the_multiline_setting_as_admin_to($plugin, $name, PyStringNode $value) {
+        set_config($name, $value->getRaw(), $plugin);
+    }
+}

--- a/tests/behat/behat_report_roster.php
+++ b/tests/behat/behat_report_roster.php
@@ -18,7 +18,7 @@
  * This file creates a behat step definition
  *
  * @package    report_roster
- * @copyright  2018 CLAMP
+ * @copyright  2019 Lafayette College
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -31,7 +31,7 @@ use Behat\Gherkin\Node\PyStringNode as PyStringNode;
  * Custom step definitions
  *
  * @package    report_roster
- * @copyright  2019 CLAMP
+ * @copyright  2019 Lafayette College
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class behat_report_roster extends behat_base {

--- a/tests/behat/flatnav.feature
+++ b/tests/behat/flatnav.feature
@@ -7,7 +7,7 @@ Feature: Option to display in Boost flat navigation
   Background:
     Given the following "courses" exist:
       | fullname | shortname | category | groupmode |
-      | Course 1 | C1 | 0 | 1 |
+      | Course 1 | C1        | 0        | 1         |
 
   @javascript
   Scenario: Display in flat navigation
@@ -22,9 +22,9 @@ Feature: Option to display in Boost flat navigation
     And I should see "Roster" in the "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element"
 
     And the following config values are set as admin:
-      | config      | value     | plugin        |
-      | flatnav     | 1         | report_roster |
-      | displayname | Headshots | report_roster |
+      | config      | value          | plugin        |
+      | flatnav     | 1              | report_roster |
+      | displayname | Something Else | report_roster |
     And I set the multiline "report_roster" "flatnav_position" setting as admin to:
     """
     competencies (Competencies)
@@ -35,12 +35,12 @@ Feature: Option to display in Boost flat navigation
     Then "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should be visible
     And "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should appear before "#nav-drawer > nav > a.list-group-item[data-key=competencies]" "css_element"
     And "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should appear after "#nav-drawer > nav > a.list-group-item[data-key=badgesview]" "css_element"
-    And I should see "Headshots" in the "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element"
+    And I should see "Something Else" in the "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element"
 
     And the following config values are set as admin:
-      | config      | value      | plugin        |
-      | flatnav     | 1          | report_roster |
-      | displayname | Head SHOTS | report_roster |
+      | config      | value          | plugin        |
+      | flatnav     | 1              | report_roster |
+      | displayname | Something ELSE | report_roster |
     And I set the multiline "report_roster" "flatnav_position" setting as admin to:
     """
     typocompetencies (Competencies)
@@ -51,4 +51,4 @@ Feature: Option to display in Boost flat navigation
     Then "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should be visible
     And "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should appear before "#nav-drawer > nav > a.list-group-item[data-key=grades]" "css_element"
     And "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should appear after "#nav-drawer > nav > a.list-group-item[data-key=competencies]" "css_element"
-    And I should see "Head SHOTS" in the "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element"
+    And I should see "Something ELSE" in the "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element"

--- a/tests/behat/flatnav.feature
+++ b/tests/behat/flatnav.feature
@@ -1,0 +1,54 @@
+@report @report_roster @report_roster_flatnav
+Feature: Option to display in Boost flat navigation
+  In order to test the flat navigation display
+  As an admin
+  I need to do some stuff
+
+  Background:
+    Given the following "courses" exist:
+      | fullname | shortname | category | groupmode |
+      | Course 1 | C1 | 0 | 1 |
+
+  @javascript
+  Scenario: Display in flat navigation
+    Given I log in as "admin"
+    And the following config values are set as admin:
+      | config  | value | plugin        |
+      | flatnav | 1     | report_roster |
+    When I am on "Course 1" course homepage
+    Then "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should be visible
+    And "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should appear before "#nav-drawer > nav > a.list-group-item[data-key=badgesview]" "css_element"
+    And "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should appear after "#nav-drawer > nav > a.list-group-item[data-key=participants]" "css_element"
+    And I should see "Roster" in the "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element"
+
+    And the following config values are set as admin:
+      | config      | value     | plugin        |
+      | flatnav     | 1         | report_roster |
+      | displayname | Headshots | report_roster |
+    And I set the multiline "report_roster" "flatnav_position" setting as admin to:
+    """
+    competencies (Competencies)
+    grades (Grades)
+    participants (Participants)
+    """
+    When I am on "Course 1" course homepage
+    Then "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should be visible
+    And "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should appear before "#nav-drawer > nav > a.list-group-item[data-key=competencies]" "css_element"
+    And "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should appear after "#nav-drawer > nav > a.list-group-item[data-key=badgesview]" "css_element"
+    And I should see "Headshots" in the "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element"
+
+    And the following config values are set as admin:
+      | config      | value      | plugin        |
+      | flatnav     | 1          | report_roster |
+      | displayname | Head SHOTS | report_roster |
+    And I set the multiline "report_roster" "flatnav_position" setting as admin to:
+    """
+    typocompetencies (Competencies)
+    grades (Grades)
+    participants (Participants)
+    """
+    When I am on "Course 1" course homepage
+    Then "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should be visible
+    And "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should appear before "#nav-drawer > nav > a.list-group-item[data-key=grades]" "css_element"
+    And "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element" should appear after "#nav-drawer > nav > a.list-group-item[data-key=competencies]" "css_element"
+    And I should see "Head SHOTS" in the "#nav-drawer > nav > a.list-group-item[data-key=report_roster]" "css_element"


### PR DESCRIPTION
There are three new settings, with corresponding functionality:
1. To display or not display a link to the report in the flat navigation
2. Display name of the roster report (will display in the navigation link)
3. Where to display the link in the flat nav, implemented as a newline separated list of link identifiers. Each identifier will be tried in succession, and the link will be inserted preceding the first one found.