### PR TITLE
Fixes #28: configurable display fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There are several options available to the admin from the Roster Report settings
 
 ### General
 
-**Show username:** If enabled, username will be shown below full name in the Roster Report.
+**Profile fields to display:** A newline separated list of profile fields to display. `fullname` is also supported. Note that custom profile fields must be entered as `profile_field_{shortname}`.
 
 **Display name:** The display string used by the Roster Report on the front end. Will appear in the flat navigation (if enabled) and on the Roster Report page.
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -38,6 +38,8 @@ function xmldb_report_roster_upgrade($oldversion) {
         if ($showusername) {
             set_config('fields', "fullname\nusername", 'report_roster');
         }
+
+        upgrade_plugin_savepoint(true, 2019091600, 'report_roster');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -31,7 +31,7 @@ defined('MOODLE_INTERNAL') || die();
  * @return bool A status indicating success or failure
  */
 function xmldb_report_roster_upgrade($oldversion) {
-    if ($oldversion < 2019091600) {
+    if ($oldversion < 2019091601) {
         // Migrate 'show_username' setting to new 'fields' setting
         $showusername = get_config('report_roster', 'show_username');
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,0 +1,44 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Define upgrade tasks for the plugin.
+ *
+ * @package   report_roster
+ * @copyright 2020 onward Lafayette College ITS
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Upgrade function for plugin.
+ *
+ * @param int $oldversion The old version of the plugin
+ * @return bool A status indicating success or failure
+ */
+function xmldb_report_roster_upgrade($oldversion) {
+    if ($oldversion <= 2019091600) {
+        // Migrate 'show_username' setting to new 'fields' setting
+        $showusername = get_config('report_roster', 'show_username');
+
+        if ($showusername) {
+            set_config('fields', "fullname\nusername", 'report_roster');
+        }
+    }
+
+    return true;
+}

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -38,6 +38,8 @@ function xmldb_report_roster_upgrade($oldversion) {
         if ($showusername) {
             set_config('fields', "fullname\nusername", 'report_roster');
         }
+
+        upgrade_plugin_savepoint(true, 2019091600, 'report', 'roster');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -31,7 +31,7 @@ defined('MOODLE_INTERNAL') || die();
  * @return bool A status indicating success or failure
  */
 function xmldb_report_roster_upgrade($oldversion) {
-    if ($oldversion <= 2019091600) {
+    if ($oldversion < 2019091600) {
         // Migrate 'show_username' setting to new 'fields' setting
         $showusername = get_config('report_roster', 'show_username');
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -38,8 +38,6 @@ function xmldb_report_roster_upgrade($oldversion) {
         if ($showusername) {
             set_config('fields', "fullname\nusername", 'report_roster');
         }
-
-        upgrade_plugin_savepoint(true, 2019091600, 'report_roster');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -39,7 +39,7 @@ function xmldb_report_roster_upgrade($oldversion) {
             set_config('fields', "fullname\nusername", 'report_roster');
         }
 
-        upgrade_plugin_savepoint(true, 2019091600, 'report', 'roster');
+        upgrade_plugin_savepoint(true, 2019091601, 'report', 'roster');
     }
 
     return true;

--- a/index.php
+++ b/index.php
@@ -74,7 +74,7 @@ foreach ($userlist as $user) {
     // Loop through configured display fields and add them.
     foreach ($fields as $field) {
         $value = report_roster_process_field($field, $user);
-        $item .= html_writer::tag('span', $value);
+        $item .= !empty($value) ? html_writer::tag('span', $value) : '';
     }
 
     $data[] = $item;

--- a/index.php
+++ b/index.php
@@ -62,8 +62,30 @@ $data = array();
 foreach ($userlist as $user) {
     if (!in_array($user->id, $suspended)) {
         $item = $OUTPUT->user_picture($user, array('size' => $size, 'courseid' => $course->id));
-        $item .= html_writer::tag('span', fullname($user));
-        $item .= get_config('report_roster', 'show_username') ? html_writer::tag('span', $user->username) : '';
+        profile_load_data($user);
+
+        $fields = explode("\n", get_config('report_roster', 'fields'));
+        foreach ($fields as $field) {
+            if (!is_string($field)) {
+                continue;
+            }
+
+            $field = trim($field);
+            $value = '';
+
+            if ($field == 'fullname') {
+                $value = fullname($user);
+            } else {
+                if (property_exists($user, $field) && !empty($user->{$field})) {
+                    $value = $user->{$field};
+                }
+            }
+
+            if (!empty($value)) {
+                $item .= html_writer::tag('span', $value);
+            }
+        }
+
         $data[] = $item;
     }
 }

--- a/lang/en/report_roster.php
+++ b/lang/en/report_roster.php
@@ -35,6 +35,11 @@ $string['roster:view'] = 'View roster course report';
 $string['settings:displayname'] = 'Display name';
 $string['settings:displayname:description'] = 'This will display on the report page and in the flat navigation link (if enabled below).';
 $string['settings:displayname:default'] = 'Roster';
+$string['settings:fields'] = 'Profile fields to display';
+$string['settings:fields:description'] = 'A list of profile fields to display in the report. Each field identifier should be on a new line. `fullname` is also supported.
+
+IMPORTANT: custom profile fields must be entered as "profile_field_{shortname}".';
+$string['settings:fields:default'] = 'fullname';
 $string['settings:flatnav'] = 'Display in flat navigation?';
 $string['settings:flatnav:description'] = 'If checked, a link to the Roster report will be added to the Boost flat navigation.
 (Under older themes like More, it will appear in the Navigation block under Current course > {coursename}.)';
@@ -52,8 +57,6 @@ participants (Participants)
 $string['settings:headings:flatnav'] = 'Flat Navigation Settings';
 $string['settings:headings:general'] = 'General Settings';
 $string['settings:headings:size'] = 'User Image Size Settings';
-$string['settings:show_username'] = 'Show username';
-$string['settings:show_username:description'] = 'Show username below fullname in the Roster Report.';
 $string['settings:size_default'] = 'Default size';
 $string['settings:size_default:description'] = 'Default user image size (when a user first opens the report).';
 $string['settings:size_large'] = 'Size: Large';

--- a/locallib.php
+++ b/locallib.php
@@ -139,4 +139,5 @@ function report_roster_process_field($field, $user) {
     } else if (property_exists($user, $field) && !empty($user->{$field}) && is_string($user->{$field})) {
         return $user->{$field};
     }
+    return false;
 }

--- a/locallib.php
+++ b/locallib.php
@@ -132,3 +132,11 @@ function report_roster_output_action_buttons($id, $url, $params) {
     $html .= html_writer::end_tag('div');
     return $html;
 }
+
+function report_roster_process_field($field, $user) {
+    if ($field == 'fullname') {
+        return fullname($user);
+    } else if (property_exists($user, $field) && !empty($user->{$field}) && is_string($user->{$field})) {
+        return $user->{$field};
+    }
+}

--- a/settings.php
+++ b/settings.php
@@ -31,10 +31,10 @@ if ($ADMIN->fulltree) {
     );
 
     $settings->add(
-        new admin_setting_configcheckbox('report_roster/show_username',
-            get_string('settings:show_username', 'report_roster'),
-            get_string('settings:show_username:description', 'report_roster'),
-            0
+        new admin_setting_configtextarea('report_roster/fields',
+            get_string('settings:fields', 'report_roster'),
+            get_string('settings:fields:description', 'report_roster'),
+            get_string('settings:fields:default', 'report_roster')
         )
     );
 

--- a/tests/behat/behat_report_roster.php
+++ b/tests/behat/behat_report_roster.php
@@ -44,4 +44,68 @@ class behat_report_roster extends behat_base {
     public function i_set_report_roster_flatnav_position_to(PyStringNode $value) {
         set_config('flatnav_position', $value->getRaw(), 'report_roster');
     }
+
+    /**
+     * Sets the 'fields' config value as admin
+     *
+     * @Given /^I set report_roster\/fields to:$/
+     * @param PyStringNode $value A triple-quote delimited text block to be set as the value of the setting
+     */
+    public function i_set_report_roster_fields_to(PyStringNode $value) {
+        set_config('fields', $value->getRaw(), 'report_roster');
+    }
+
+    /**
+     * Creates a dummy custom profile field called 'test_custom_field'
+     *
+     * @Given /^I create a dummy custom profile field$/
+     */
+    public function i_create_a_dummy_custom_profile_field() {
+        global $DB;
+
+        if ($DB->record_exists('user_info_field', array('shortname' => 'test_custom_field'))) {
+            return;
+        }
+
+        $field = new stdClass();
+        $field->shortname = 'test_custom_field';
+        $field->name = 'Test Custom Field';
+        $field->datatype = 'text';
+        $field->categoryid = 1;
+        $DB->insert_record('user_info_field', $field);
+    }
+
+    /**
+     * Set a custom profile field for a given user
+     *
+     * @Given /^I set the custom profile field "([^"]*)" to "([^"]*)" for user "([^"]*)"$/
+     * @param string $field The shortname of the targetfield
+     * @param string $value The value to set
+     * @param string $user The username of the target user
+     */
+    public function i_set_the_custom_profile_field_to_for_user($field, $value, $user) {
+        global $DB;
+
+        $fielddata = $DB->get_record('user_info_field', array('shortname' => $field));
+        $user = $DB->get_record('user', array('username' => $user));
+
+        if (!empty($fielddata) && !empty($user)) {
+            $data = new stdClass();
+            $data->userid = $user->id;
+            $data->fieldid = $fielddata->id;
+            $data->data = $value;
+
+            $existing = $DB->get_record('user_info_data', array(
+                'userid' => $user->id,
+                'fieldid' => $fielddata->id,
+            ));
+
+            if (!empty($existing)) {
+                $data->id = $existing->id;
+                $DB->update_record('user_info_data', $data);
+            } else {
+                $DB->insert_record('user_info_data', $data);
+            }
+        }
+    }
 }

--- a/tests/behat/fields.feature
+++ b/tests/behat/fields.feature
@@ -1,0 +1,48 @@
+@report @report_roster @report_roster_fields
+Feature: An administrator may configure the displayed profile fields
+  In order to display different profile fields
+  As an administrator
+  I need to set some settings
+
+  @javascript
+  Scenario: Test configurable profile field display
+    Given I create a dummy custom profile field
+    Given the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+    And the following "users" exist:
+      | username | firstname | lastname | email                 |
+      | hpotter  | Harry     | Potter   | hpotter@hogwarts.wiz  |
+      | hgranger | Hermione  | Granger  | hgranger@hogwarts.wiz |
+      | rweasley | Runil     | Wazlib   | rweasley@hogwarts.wiz |
+    And I set the custom profile field "test_custom_field" to "pottertest" for user "hpotter"
+    And I set the custom profile field "test_custom_field" to "grangertest" for user "hgranger"
+    And I set the custom profile field "test_custom_field" to "weasleytest" for user "rweasley"
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | hpotter  | C1     | student |
+      | hgranger | C1     | student |
+      | rweasley | C1     | student |
+    Given I log in as "admin"
+    And I am on "Course 1" course homepage
+    And I navigate to "Reports > Roster" in current page administration
+    Then I should see "Harry Potter"
+    Then I should see "Hermione Granger"
+    Then I should see "Runil Wazlib"
+
+    Given I set report_roster/fields to:
+    """
+    email
+    profile_field_test_custom_field
+    """
+    And I am on "Course 1" course homepage
+    And I navigate to "Reports > Roster" in current page administration
+    Then I should not see "Harry Potter"
+    Then I should not see "Hermione Granger"
+    Then I should not see "Runil Wazlib"
+    Then I should see "hpotter@hogwarts.wiz"
+    Then I should see "hgranger@hogwarts.wiz"
+    Then I should see "rweasley@hogwarts.wiz"
+    Then I should see "pottertest"
+    Then I should see "grangertest"
+    Then I should see "weasleytest"

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2019091600;
+$plugin->version   = 2019091601;
 $plugin->requires  = 2018120300;
 $plugin->component = 'report_roster';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
This does several things to enable this functionality:

1. Replace the checkbox `show_username` with the textarea `fields` which is a newline-separated list of profile field shortnames. As documented in the README and the setting description, custom profile fields are supported but must be entered as `profile_field_{shortname}`. This setting also allows the use of `fullname` (which is not a static profile field).

2. The output code now loops over the configured fields and displays any that it finds, as long as the value is a string and not empty.

3. Added a behat test for this functionality.

4. Added an upgrade path. The default value of `report_roster/fields` is `fullname`. But if the `show_username` setting was previously set to true, then that is replaced by
```
fullname
username
```
on upgrade. The only downside here is that setting this setting in the upgrade code causes it not to show up as a new setting during the UI upgrade process; not sure how much we care about that. Not sure that there is a reasonable alternative other than simply not having an upgrade path (which is not necessarily unreasonable, since if someone did have `show_username` set to true, it should be fairly obvious how the change will effect that when they see the new setting).