### PR TITLE
Fixes #32: all fields now display, not just the last one

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -134,6 +134,7 @@ function report_roster_output_action_buttons($id, $url, $params) {
 }
 
 function report_roster_process_field($field, $user) {
+    $field = trim($field);
     if ($field == 'fullname') {
         return fullname($user);
     } else if (property_exists($user, $field) && !empty($user->{$field}) && is_string($user->{$field})) {

--- a/tests/behat/fields.feature
+++ b/tests/behat/fields.feature
@@ -33,7 +33,9 @@ Feature: An administrator may configure the displayed profile fields
     Given I set report_roster/fields to:
     """
     email
+
     profile_field_test_custom_field
+
     """
     And I am on "Course 1" course homepage
     And I navigate to "Reports > Roster" in current page administration


### PR DESCRIPTION
During a pre-merge refactor, the `trim` function (that was being performed on each exploded line of the multi-line `fields` config) was inadvertently removed. The developer unwisely chose not to manually confirm that the refactor had not introduced any bugs, and simply ran the Behat tests. The Behat tests did not catch the lack of `trim`ming because the configuration inserted within the test had a truly single newline, whereas configuration entered via the browser more often than not comes through with some other white space introduced (I'm assuming a carriage return or the like?).