### PR TITLE
Moodle 311

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -35,15 +35,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
-        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'master']
+        php: ['7.3', '7.4', '8.0']
+        moodle-branch: ['MOODLE_311_STABLE', 'master']
         database: [pgsql, mariadb]
-
-        include:
-          - {moodle-branch: 'MOODLE_311_STABLE', php: '8.0', operating-system: 'ubuntu-18.04', database: 'mariadb'}
-          - {moodle-branch: 'MOODLE_311_STABLE', php: '8.0', operating-system: 'ubuntu-18.04', database: 'pgsql'}
-          - {moodle-branch: 'master', php: '8.0', operating-system: 'ubuntu-18.04', database: 'mariadb'}
-          - {moodle-branch: 'master', php: '8.0', operating-system: 'ubuntu-18.04', database: 'pgsql'}
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -1,6 +1,14 @@
 name: Moodle Plugin CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+  schedule:
+    - cron: '0 8 * * 4'
 
 jobs:
   test:
@@ -27,9 +35,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4', '8.0']
+        php: ['7.3', '7.4']
         moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'master']
         database: [pgsql, mariadb]
+
+        include:
+          - {moodle-branch: 'MOODLE_311_STABLE', php: '8.0', operating-system: 'ubuntu-18.04', database: 'mariadb'}
+          - {moodle-branch: 'MOODLE_311_STABLE', php: '8.0', operating-system: 'ubuntu-18.04', database: 'pgsql'}
+          - {moodle-branch: 'master', php: '8.0', operating-system: 'ubuntu-18.04', database: 'mariadb'}
+          - {moodle-branch: 'master', php: '8.0', operating-system: 'ubuntu-18.04', database: 'pgsql'}
 
     steps:
       - name: Check out repository code
@@ -75,7 +89,7 @@ jobs:
 
       - name: Moodle Code Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci codechecker --max-warnings 0
+        run: moodle-plugin-ci codechecker
 
       - name: Moodle PHPDoc Checker
         if: ${{ always() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Change default branch to "main"
 - Update CI tool to version 3
-- Dropped support for Moodle 3.6-Moodle 3.8
-- Added support for Moodle 3.10-3.11
+- Dropped support for Moodle 3.6-Moodle 3.10
+- Added support for Moodle 3.11
 - Move testing to Github Actions
 
 ## 3.6.3 (July 22, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [Bugfix] Update internal API in light of [MDL-45242](https://tracker.moodle.org/browse/MDL-45242)
 - Change default branch to "main"
 - Update CI tool to version 3
 - Dropped support for Moodle 3.6-Moodle 3.10

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is a simple report which displays the user pictures for everyone enrolled in the given course.
 
 ## Requirements
-- Moodle 3.7 (build 2019052000 or later)
+- Moodle 3.11 (build 2021051700 or later)
 
 ## Installation
 Copy the roster folder into your /report directory and visit your Admin Notification page to complete the installation.

--- a/lib.php
+++ b/lib.php
@@ -57,7 +57,7 @@ function report_roster_add_to_flatnav() {
         get_config('report_roster', 'displayname'),   // Link text.
         '/report/roster/index.php?id=' . $COURSE->id, // URL.
         navigation_node::TYPE_SETTING,                // Node type.
-        null,                                         // "Shorttext".
+        null,                                         // Shorttext.
         'report_roster',                              // Key.
         new pix_icon('t/roster', '', 'report_roster') // Icon.
     );

--- a/locallib.php
+++ b/locallib.php
@@ -193,16 +193,21 @@ function report_roster_resolve_auto_size() {
 function report_roster_profile_fields_query() {
     global $DB, $USER;
 
+    // Set extra fields to retrieve.
+    $extrafields = ['username', 'timezone'];
     $fieldsconfig = explode("\n", get_config('report_roster', 'fields'));
-    $fields = user_picture::fields('u', ['username'], 0, 0, true) . ',u.timezone';
-
     foreach ($fieldsconfig as $field) {
         $field = trim($field);
 
         if ( property_exists($USER, $field)) {
-            $fields .= ',u.' . $field;
+            $extrafields[] = $field;
         }
     }
 
-    return $fields;
+    $fields = \core_user\fields::for_userpic();
+    $fields->including(...$extrafields);
+
+    $selects = $fields->get_sql('u', false, '', 'id', false)->selects;
+    $selects = str_replace(', ', ',', $selects);
+    return $selects;
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->version   = 2020072200;
-$plugin->requires  = 2019052000;
+$plugin->requires  = 2021051700;
 $plugin->component = 'report_roster';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = 'v3.6.3';


### PR DESCRIPTION
The main change here is rewriting `report_roster_profile_fields_query()` in light of [MDL-45242](https://tracker.moodle.org/browse/MDL-45242). This requires dropping support for versions prior to Moodle 3.11.0 to avoid the deprecation warnings in test.